### PR TITLE
Use an iterable as data structure for yourchoice

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,33 +37,17 @@ Is invoked when item is added to the selection.
 
 Is invoked when item is removed from the selection.
 
-## Iterator Interface
+## Iterable Interface
 
-Any [javascript iterator](http://www.ecma-international.org/ecma-262/6.0/#sec-iterator-interface). Should iterate over the data structure that represents the items that can be selected. This enables YourChoice to operate on any data structure. A simple array iterator could look like this:
+Any [javascript iterable](http://www.ecma-international.org/ecma-262/6.0/#sec-iterable-interface). Should be implemented by the data structure that represents the items that can be selected. This enables YourChoice to operate on any data structure. Native data types such as `Array` or `Map` implement the iterable protocol.
 
-```javascript
-var arrayIterator = {
-  next: function() {
-    var value = index < array.length ? array[index] : undefined;
-    index++;
-    return {
-      value: value,
-      done: value == null
-    };
-  }
-}
-```
+## YourChoice(iterable)
 
-## YourChoice(iteratorFactory)
-
-`iteratorFactory` – a function returning an iterator
+`iterable` – an object that implements the `Iterable` interface, representing the list of items that can be selected.
 
 ```javascript
-var iteratorFactory = function() {
-  var iterator = {...};
-  return iterator;
-}
-var yourChoice = new YourChoice(iteratorFactory);
+var iterable = ['A', 'B', 'C', 'D']
+var yourChoice = new YourChoice(iterable);
 ```
 
 ## YourChoice.selectedItems

--- a/src/selection.js
+++ b/src/selection.js
@@ -5,11 +5,9 @@ import { sameMembers } from './array'
 
 class Selection extends Emitter {
 
-  constructor(iteratorFactory) {
+  constructor(iterable) {
     super()
-    this.iterable = {
-      [Symbol.iterator]: iteratorFactory,
-    }
+    this.iterable = iterable
     this.selectedItems = []
     this.lastAnchor = null
   }

--- a/test/selection-unit.js
+++ b/test/selection-unit.js
@@ -24,19 +24,15 @@ describe('selection', () => {
     }
   }
 
-  function arrayIterator(array) {
-    return array[Symbol.iterator]()
-  }
-
   it('should have no selected items initially', () => {
-    const selection = new Selection(arrayIterator([]))
+    const selection = new Selection([])
     expectExactlySameMembers(selection.selectedItems, [])
   })
 
   describe('replace selection with single item', () => {
     it('should replace empty selection with single item', () => {
       const item = new Item()
-      const selection = new Selection(() => arrayIterator([item]))
+      const selection = new Selection([item])
 
       selection.replace(item)
 
@@ -51,7 +47,7 @@ describe('selection', () => {
       beforeEach(() => {
         itemList = createItemList(5)
         item = new Item()
-        selection = new Selection(() => arrayIterator(itemList))
+        selection = new Selection(itemList)
 
         for (let i = 0; i < itemList.length; i++) {
           const otherItem = itemList[i]
@@ -119,7 +115,7 @@ describe('selection', () => {
 
     it('should not emit change event when only this item was selected', () => {
       const item = new Item()
-      const selection = new Selection(() => arrayIterator([item]))
+      const selection = new Selection([item])
       selection.replace(item)
       const changeListener = sinon.stub()
       selection.on('change', changeListener)
@@ -134,7 +130,7 @@ describe('selection', () => {
     describe('item is not selected', () => {
       it('should add single item to empty selection', () => {
         const item = new Item()
-        const selection = new Selection(() => arrayIterator([item]))
+        const selection = new Selection([item])
 
         selection.toggle(item)
 
@@ -143,7 +139,7 @@ describe('selection', () => {
 
       it('should mark item as selected', () => {
         const item = new Item()
-        const selection = new Selection(() => arrayIterator([item]))
+        const selection = new Selection([item])
 
         selection.toggle(item)
 
@@ -152,7 +148,7 @@ describe('selection', () => {
 
       it('should add single item to existing selection', () => {
         const itemList = createItemList(5)
-        const selection = new Selection(() => arrayIterator(itemList))
+        const selection = new Selection(itemList)
 
         for (let i = 0; i < itemList.length; i++) {
           const item = itemList[i]
@@ -164,7 +160,7 @@ describe('selection', () => {
 
       it('should emit change event with selected items', (done) => {
         const item = new Item()
-        const selection = new Selection(() => arrayIterator([item]))
+        const selection = new Selection([item])
 
         selection.on('change', (selectedItems) => {
           expectExactlySameMembers(selectedItems, [item])
@@ -178,7 +174,7 @@ describe('selection', () => {
     describe('item is already selected', () => {
       it('should remove single item from selection', () => {
         const item = new Item()
-        const selection = new Selection(() => arrayIterator([item]))
+        const selection = new Selection([item])
 
         selection.toggle(item)
         selection.toggle(item)
@@ -188,7 +184,7 @@ describe('selection', () => {
 
       it('should mark item as deselected', () => {
         const item = new Item()
-        const selection = new Selection(() => arrayIterator([item]))
+        const selection = new Selection([item])
 
         selection.toggle(item)
         selection.toggle(item)
@@ -198,7 +194,7 @@ describe('selection', () => {
 
       it('should remove single item from existing selection', () => {
         const itemList = createItemList(5)
-        const selection = new Selection(() => arrayIterator(itemList))
+        const selection = new Selection(itemList)
 
         for (let i = 0; i < itemList.length; i++) {
           const item = itemList[i]
@@ -217,7 +213,7 @@ describe('selection', () => {
 
       it('should emit change event', (done) => {
         const item = new Item()
-        const selection = new Selection(() => arrayIterator([item]))
+        const selection = new Selection([item])
 
         selection.toggle(item)
 
@@ -231,7 +227,7 @@ describe('selection', () => {
 
       it('should emit copy of selected items on change event', () => {
         const itemList = createItemList(3)
-        const selection = new Selection(() => arrayIterator(itemList))
+        const selection = new Selection(itemList)
 
         const changeEventParameters = []
         selection.on('change', (selectedItems) => changeEventParameters.push(selectedItems))
@@ -253,7 +249,7 @@ describe('selection', () => {
 
     beforeEach(() => {
       itemList = createItemList(5)
-      selection = new Selection(() => arrayIterator(itemList))
+      selection = new Selection(itemList)
     })
 
     it('should deselect a list of items', () => {
@@ -329,7 +325,7 @@ describe('selection', () => {
 
     beforeEach(() => {
       itemList = createItemList(5)
-      selection = new Selection(() => arrayIterator(itemList))
+      selection = new Selection(itemList)
     })
 
     describe('from top to bottom', () => {


### PR DESCRIPTION
This is a breaking change. The interface of yourchoice now uses a javascript iterable. This makes the usage a lot easier when yourchoice is used in a ES-2015 context.

This change will require a new major version. It is supposed to be the basis for a purely functional interface that can then be wrapped by e.g. react/redux reducers.