### PR TITLE
Notify when an item has been deselected by altering the iterable from the outside

### DIFF
--- a/src/operations.js
+++ b/src/operations.js
@@ -1,6 +1,7 @@
 import {
   clone,
   curry,
+  difference,
   flow,
   includes,
   intersection,
@@ -27,7 +28,7 @@ const setItems = curry((itemsIterable, state) => {
     selected: intersection(state.selected, items),
     changed: {
       selected: [],
-      deselected: [],
+      deselected: difference(state.selected, items),
     },
     anchor: includes(state.anchor, items) ? state.anchor : null,
   }

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,5 +1,4 @@
 import Emitter from 'component-emitter'
-import { flow } from 'lodash/fp'
 
 import {
   init,
@@ -24,10 +23,8 @@ class Selection extends Emitter {
   }
 
   toggle(item) {
-    this.state = flow(
-      setItems(this.iterable),
-      toggle(item)
-    )(this.state)
+    this._setItemsAndNotify()
+    this.state = toggle(item, this.state)
 
     this._updateSelectedItems()
     this._notifyChangedItems()
@@ -35,10 +32,8 @@ class Selection extends Emitter {
   }
 
   replace(item) {
-    this.state = flow(
-      setItems(this.iterable),
-      replace(item)
-    )(this.state)
+    this._setItemsAndNotify()
+    this.state = replace(item, this.state)
 
     this._updateSelectedItems()
     this._notifyChangedItems()
@@ -46,11 +41,7 @@ class Selection extends Emitter {
   }
 
   remove(items) {
-    this.state = setItems(this.iterable, this.state)
-    this._updateSelectedItems()
-    this._notifyChangedItems()
-    this._emitChangeEvent()
-
+    this._setItemsAndNotify()
     this.state = remove(items, this.state)
 
     this._updateSelectedItems()
@@ -59,10 +50,8 @@ class Selection extends Emitter {
   }
 
   removeAll() {
-    this.state = flow(
-      setItems(this.iterable),
-      removeAll()
-    )(this.state)
+    this._setItemsAndNotify()
+    this.state = removeAll(this.state)
 
     this._updateSelectedItems()
     this._notifyChangedItems()
@@ -70,10 +59,8 @@ class Selection extends Emitter {
   }
 
   rangeTo(endItem) {
-    this.state = flow(
-      setItems(this.iterable),
-      rangeTo(endItem)
-    )(this.state)
+    this._setItemsAndNotify()
+    this.state = rangeTo(endItem, this.state)
 
     this._updateSelectedItems()
     this._notifyChangedItems()
@@ -100,6 +87,13 @@ class Selection extends Emitter {
     if (change) {
       this.emit('change', this.selectedItems.slice())
     }
+  }
+
+  _setItemsAndNotify() {
+    this.state = setItems(this.iterable, this.state)
+    this._updateSelectedItems()
+    this._notifyChangedItems()
+    this._emitChangeEvent()
   }
 
 }

--- a/src/selection.js
+++ b/src/selection.js
@@ -46,10 +46,12 @@ class Selection extends Emitter {
   }
 
   remove(items) {
-    this.state = flow(
-      setItems(this.iterable),
-      remove(items)
-    )(this.state)
+    this.state = setItems(this.iterable, this.state)
+    this._updateSelectedItems()
+    this._notifyChangedItems()
+    this._emitChangeEvent()
+
+    this.state = remove(items, this.state)
 
     this._updateSelectedItems()
     this._notifyChangedItems()

--- a/test/selection-unit.js
+++ b/test/selection-unit.js
@@ -308,25 +308,6 @@ describe('selection', () => {
       selection.remove([itemList[1], itemList[2]])
     })
 
-    it('should emit change event even if iterable has been changed from the outside', () => {
-      selection.toggle(itemList[0])
-      selection.toggle(itemList[1])
-      selection.toggle(itemList[2])
-      selection.toggle(itemList[4])
-
-      const changeListener = sinon.spy()
-
-      selection.on('change', changeListener)
-
-      const itemToRemove = itemList[0]
-      itemList.splice(0, 1)
-
-      selection.remove([itemToRemove])
-
-      expect(changeListener).to.have.been.calledWith([itemList[0], itemList[1], itemList[3]])
-    })
-
-
     it('should not emit change event when selection does not change', () => {
       selection.toggle(itemList[0])
       selection.toggle(itemList[1])
@@ -605,6 +586,24 @@ describe('selection', () => {
           itemList[4],
         ])
       })
+    })
+  })
+  describe('notify about changed items when setting items with iterable', () => {
+    it('should notify on iterable change from the outside', () => {
+      const itemList = createItemList(2)
+      const selection = new Selection(itemList)
+
+      selection.toggle(itemList[0])
+      selection.toggle(itemList[1])
+
+      const changeListener = sinon.spy()
+      selection.on('change', changeListener)
+      const item1 = itemList[1]
+
+      itemList.splice(0, 1)
+      selection._setItemsAndNotify()
+
+      expect(changeListener).to.have.been.calledWith([item1])
     })
   })
 

--- a/test/selection-unit.js
+++ b/test/selection-unit.js
@@ -308,6 +308,25 @@ describe('selection', () => {
       selection.remove([itemList[1], itemList[2]])
     })
 
+    it('should emit change event even if iterable has been changed from the outside', () => {
+      selection.toggle(itemList[0])
+      selection.toggle(itemList[1])
+      selection.toggle(itemList[2])
+      selection.toggle(itemList[4])
+
+      const changeListener = sinon.spy()
+
+      selection.on('change', changeListener)
+
+      const itemToRemove = itemList[0]
+      itemList.splice(0, 1)
+
+      selection.remove([itemToRemove])
+
+      expect(changeListener).to.have.been.calledWith([itemList[0], itemList[1], itemList[3]])
+    })
+
+
     it('should not emit change event when selection does not change', () => {
       selection.toggle(itemList[0])
       selection.toggle(itemList[1])

--- a/test/set-items.ut.js
+++ b/test/set-items.ut.js
@@ -1,5 +1,6 @@
 import { flow } from 'lodash/fp'
 import {
+  getChangedDeselection,
   getSelection,
   init,
   rangeTo,
@@ -24,6 +25,17 @@ describe('setItems - updating the list of selectable items', () => {
       expectExactlySameMembers(getSelection(newState), ['C'])
     })
 
+    it('should return previously selected items as newly deselected', () => {
+      const state = init()
+
+      const newState = flow(
+        setItems(iterable(['A', 'B'])),
+        setSelection(['B']),
+        setItems(iterable(['A']))
+      )(state)
+
+      expectExactlySameMembers(getChangedDeselection(newState), ['B'])
+    })
   })
 
   it('should remove item from anchor that doesn\'t exist anymore', () => {

--- a/test/set-items.ut.js
+++ b/test/set-items.ut.js
@@ -11,16 +11,19 @@ import { iterable, expectExactlySameMembers } from './helper'
 
 
 describe('setItems - updating the list of selectable items', () => {
-  it('should remove items from selection that don\'t exist anymore', () => {
-    const state = init()
+  describe('remove selected items', () => {
+    it('should remove items from selection that don\'t exist anymore', () => {
+      const state = init()
 
-    const newState = flow(
-      setItems(iterable(['A', 'B', 'C', 'D'])),
-      setSelection(['B', 'C']),
-      setItems(iterable(['A', 'C', 'D']))
-    )(state)
+      const newState = flow(
+        setItems(iterable(['A', 'B', 'C', 'D'])),
+        setSelection(['B', 'C']),
+        setItems(iterable(['A', 'C', 'D']))
+      )(state)
 
-    expectExactlySameMembers(getSelection(newState), ['C'])
+      expectExactlySameMembers(getSelection(newState), ['C'])
+    })
+
   })
 
   it('should remove item from anchor that doesn\'t exist anymore', () => {


### PR DESCRIPTION
In the imperative implementation (deprecated but still used in our product) it is possible to change the iterable from the outside, e.g.
```javascript
const myArray = ['A', 'B', 'C']
const selection = new Selection(myArray)
myArray.splice(0, 1)
```

Because this is possible, we call `setItems` on every operation to get the updated item iterable into the internal state.

When doing this, we do two operations but get false change events afterwards because we only compare what has changed _in the last operation_. That's why we need to additionally notify after the call of `setItems`. We need to do this for every operation. It may not be sufficient to only test this private method (see last commit). The alternative is to test this in every API method (which I really don't like – imagine the test in https://github.com/actano/yourchoice/commit/13dbf493bb691a6607c31f79a5e9c376161ee120 for all methods).

I'm not really happy with this solution. I like to get some opinions of you guys. Maybe we should not even allow doing this since it makes things more complicated than they need to be. 

@ChristophVitz-Actano @m-lautenbach @weltenwort 